### PR TITLE
numpy2 and gdal upgrade changes

### DIFF
--- a/nbs/bruty/attribute_tables.py
+++ b/nbs/bruty/attribute_tables.py
@@ -12,6 +12,8 @@ from nbs.bruty.contributor_metadata import contributor_metadata_from_file, DEFAU
 from nbs.bruty.constants import CONTRIBUTOR_BAND_NAME
 from nbs.bruty.raster_funcs import raster_band_name_index
 
+gdal.DontUseExceptions()
+
 # constants for field names in the raster attribute tables, based on the BAG update spec derived and S101
 VALUE = 'value'
 COUNT = 'count'

--- a/nbs/bruty/generalize.py
+++ b/nbs/bruty/generalize.py
@@ -24,6 +24,8 @@ from nbs.bruty.constants import CONTRIBUTOR_BAND_NAME, ELEVATION_BAND_NAME, UNCE
 from nbs_utils.gdal_utils import where_not_nodata
 from nbs.bruty.utils import iterate_gdal_image, BufferedImageOps
 
+gdal.DontUseExceptions()
+
 LOGGER = get_logger('bruty.generalize')
 CONFIG_SECTION = 'combined_raster_processing'
 

--- a/nbs/bruty/nbs_postgres.py
+++ b/nbs/bruty/nbs_postgres.py
@@ -19,6 +19,8 @@ from data_management.db_connection import connect_with_retries
 from fuse_dev.fuse.meta_review.meta_review import database_has_table, split_URL_port
 from nbs.debugging import log_calls
 
+gdal.DontUseExceptions()
+
 _debug = False
 
 REVIEWED = "qualified"

--- a/nbs/bruty/raster_attribute_table.py
+++ b/nbs/bruty/raster_attribute_table.py
@@ -15,6 +15,8 @@ from nbs.configs import get_logger, iter_configs, log_config, set_stream_logging
 from nbs.bruty.constants import CONTRIBUTOR_BAND_NAME, ELEVATION_BAND_NAME, UNCERTAINTY_BAND_NAME
 from nbs.bruty.raster_funcs import raster_band_name_index
 
+gdal.DontUseExceptions()
+
 LOGGER = get_logger('xipe.scripts.RAT')
 CONFIG_SECTION = 'combined_raster_processing'
 QUALITY_BAND_NAME = "Quality"

--- a/nbs/bruty/raster_data.py
+++ b/nbs/bruty/raster_data.py
@@ -12,6 +12,9 @@ from osgeo import gdal, osr
 from nbs.bruty.abstract import VABC, abstractmethod
 from nbs.bruty.utils import affine, affine_center, inv_affine, remove_file
 
+gdal.DontUseExceptions()
+osr.DontUseExceptions()
+
 # investigated the two choices:
 #   store full data arrays which should be faster and deltas could be created vs storing deltas which may be smaller but slower
 #   By storing the full data in the last position and deltas for everything leading up performance is good for the normal case of adding data

--- a/nbs/bruty/tile_export.py
+++ b/nbs/bruty/tile_export.py
@@ -15,7 +15,7 @@ import glob
 from functools import total_ordering
 
 from shapely import wkt, wkb
-from osgeo import ogr, osr, gdal
+from osgeo import gdal
 import pickle
 from functools import partial
 
@@ -50,6 +50,7 @@ from nbs.bruty.raster_funcs import  raster_band_name_index
 from nbs.scripts.tile_specs import create_world_db, SUCCEEDED, TILE_LOCKED, UNHANDLED_EXCEPTION, DATA_ERRORS, \
     TileInfo, ResolutionTileInfo, CombineTileInfo
 
+gdal.DontUseExceptions()
 
 LOGGER = get_logger('nbs.bruty.export')
 VERSION = (1, 0, 0)

--- a/nbs/bruty/utils.py
+++ b/nbs/bruty/utils.py
@@ -15,6 +15,9 @@ import pyproj.exceptions
 from pyproj import Transformer, CRS
 from nbs.bruty.exceptions import BrutyFormatError, BrutyMissingScoreError, BrutyUnkownCRS, BrutyError
 
+gdal.DontUseExceptions()
+osr.DontUseExceptions()
+
 if os.name == 'posix':
     import fcntl
     import termios
@@ -804,7 +807,7 @@ def save_soundings_from_image(inputname, outputname, res, flip_depth=True):
         if 0 != lyr.CreateField(field):
             raise RuntimeError("Creating field failed.", field.GetName())
 
-    sounding_array = sounding_array.astype(numpy.float).T
+    sounding_array = sounding_array.astype(float).T
     for x, y, z in sounding_array:
         point = ogr.Geometry(ogr.wkbPoint)
         point.AddPoint(float(x), float(y), float(z))

--- a/nbs/bruty/vr_utils.py
+++ b/nbs/bruty/vr_utils.py
@@ -24,6 +24,8 @@ from nbs.bruty import morton, world_raster_database
 from nbs.bruty.utils import tqdm, iterate_gdal_image, onerr
 from nbs.bruty.raster_data import affine, inv_affine, affine_center, LayersEnum
 
+gdal.DontUseExceptions()
+
 _debug = False
 
 if _debug or not has_numba:  # turn off jit --

--- a/nbs/bruty/world_raster_database.py
+++ b/nbs/bruty/world_raster_database.py
@@ -44,6 +44,8 @@ from nbs.bruty.exceptions import BrutyFormatError, BrutyMissingScoreError, Bruty
 from nbs.configs import get_logger, set_file_logging, make_family_of_logs, close_logs  # , iter_configs, log_config, parse_multiple_values
 from nbs.debugging import get_call_logger, log_calls, get_dbg_log_path
 
+gdal.DontUseExceptions()
+
 geo_debug = False
 _debug = False
 NO_OVERRIDE = -1
@@ -2658,8 +2660,8 @@ class WorldDatabase(VABC):
         txs, tys = self.db.tile_scheme.xy_to_tile_index(numpy.array([x1, x2]), numpy.array([y1, y2]))
         txs = list(range(min(txs), max(txs) + 1))
         tys = list(range(min(tys), max(tys) + 1))
-        cols = numpy.zeros(len(txs), numpy.int)
-        rows = numpy.zeros(len(tys), numpy.int)
+        cols = numpy.zeros(len(txs), int)
+        rows = numpy.zeros(len(tys), int)
 
         # # @todo figure out the starting position and what its row/column is and make that the origin
         # nr, nc = self.init_tile(txs[0], tys[0], None)

--- a/nbs/scripts/combine.py
+++ b/nbs/scripts/combine.py
@@ -15,7 +15,7 @@ import sqlite3
 import io
 
 import numpy
-from osgeo import gdal, osr, ogr
+from osgeo import gdal, ogr
 
 from nbs.bruty import world_raster_database
 from nbs.bruty.world_raster_database import WorldDatabase, use_locks, UTMTileBackendExactRes, NO_OVERRIDE
@@ -30,6 +30,7 @@ from nbs.scripts.tile_specs import TileInfo, CombineTileInfo, ResolutionTileInfo
 from nbs_utils.points_utils import to_npz
 from nbs.debugging import log_calls, get_call_logger, get_dbg_log_path, setup_call_logger
 
+gdal.DontUseExceptions()
 
 interactive_debug = False
 if interactive_debug and sys.gettrace() is None:  # this only is set when a debugger is run (?)

--- a/nbs/scripts/find_bad_files.py
+++ b/nbs/scripts/find_bad_files.py
@@ -39,6 +39,7 @@ except:
     from nbs_utils.points_utils import from_npz, to_npz
     import numpy
     from osgeo import gdal
+    gdal.DontUseExceptions()
 
     is_caris = False
 

--- a/nbs/scripts/find_missing_uncertainty.py
+++ b/nbs/scripts/find_missing_uncertainty.py
@@ -3,6 +3,8 @@ import sys
 from osgeo import gdal
 import numpy
 
+gdal.DontUseExceptions()
+
 def find_missing_uncert(fname):
     """ Find pixels where uncertainty is missing but depth is present
     Parameters

--- a/nbs/scripts/metrics.py
+++ b/nbs/scripts/metrics.py
@@ -5,6 +5,8 @@ from osgeo import gdal
 
 from nbs.bruty import attribute_tables
 
+gdal.DontUseExceptions()
+
 institutions = {0:{}, 1:{}}
 all_fnames = [fname for fname in glob.glob("v:\\bruty_tile_exports\\**\\*.tif", recursive=True) if "original" not in fname]
 use_files = {14:{}, 15:{}, 16:{}}

--- a/nbs/scripts/tile_specs.py
+++ b/nbs/scripts/tile_specs.py
@@ -20,6 +20,8 @@ from nbs.bruty.nbs_postgres import NOT_NAV, get_nbs_records, get_sorting_info, g
 from nbs.bruty.world_raster_database import WorldDatabase, use_locks, UTMTileBackendExactRes, NO_OVERRIDE, BaseLockException
 from nbs.bruty.utils import ConsoleProcessTracker
 
+gdal.DontUseExceptions()
+
 NO_DATA = -1
 SUCCEEDED = 0
 DATA_ERRORS = 3

--- a/scripts/flip_bruty_tiffs.py
+++ b/scripts/flip_bruty_tiffs.py
@@ -7,8 +7,9 @@ import pathlib
 
 import numpy
 from osgeo import gdal
-gdal.UseExceptions()
 from nbs.bruty.world_raster_database import WorldDatabase
+
+gdal.UseExceptions()
 
 """
 ## PBG19     3 180    size GB : 11.45   file count:  27247

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -14,6 +14,9 @@ from nbs.bruty.constants import CONTRIBUTOR_BAND_NAME, ELEVATION_BAND_NAME, UNCE
 from test_data import master_data, make_clean_dir, data_dir, SW_5x5, NW_5x5, SE_5x5, MID_5x5
 from nbs.configs import get_logger, iter_configs, set_file_logging, log_config, parse_multiple_values
 
+gdal.DontUseExceptions()
+osr.DontUseExceptions()
+
 LOGGER = get_logger("nbs.bruty.tests")
 
 nan = numpy.nan

--- a/tests/test_vr_utils.py
+++ b/tests/test_vr_utils.py
@@ -19,6 +19,9 @@ from nbs.bruty import utils
 
 from test_data import master_data, make_clean_dir, data_dir, SW_5x5, NW_5x5, SE_5x5, MID_5x5
 
+gdal.DontUseExceptions()
+osr.DontUseExceptions()
+
 nan = numpy.nan
 os.makedirs(data_dir, exist_ok=True)
 

--- a/tests/test_world_database.py
+++ b/tests/test_world_database.py
@@ -20,6 +20,9 @@ from nbs_utils.points_utils import to_npz
 from test_data import master_data, make_clean_dir, data_dir, SW_5x5, NW_5x5, SE_5x5, MID_5x5
 from nbs.configs import get_logger, iter_configs, set_file_logging, log_config, parse_multiple_values
 
+gdal.DontUseExceptions()
+osr.DontUseExceptions()
+
 LOGGER = get_logger("nbs.bruty.tests")
 
 nan = numpy.nan


### PR DESCRIPTION
We are trying to upgrade the fuse environment to use numpy2 and are upgrading gdal to 3.10.3. Because the NBS process uses Bruty in the same env we need to change some of the code but all the changes work with the current python and library versions.

Numpy 2.x gets rid of some of the redundant types like numpy.int and numpy.float because they are just bindings for the built in python float and int. This means numpy changes in my branch have no functional impact and should work fine in numpy 1.x versions as well as numpy 2.x versions.

For gdal in 3.10 versions UseExceptions is now the default behavior so instead or returning a code error (like returning 6 when something fails) gdal now defaults to returning a python error. This breaks some of our code which is expecting an error code. I have not changed the .pys that already had UseExceptions but I did move it to after the import block to match the nbs codebase. 

I could try to look through each .py and determine if they need the don't use exceptions added ( because there is something expecting an error code instead) or not but its not always easy to test these codebases so we have gone the safe route of adding it where gdal is imported. 

Now that I think about it the code might have been written for a newer gdal because you do specify use exception so if thats the case I can remove the (probably redundant) don't use exceptions lines.